### PR TITLE
feat: auto-generate README dependency lists from Wizard API

### DIFF
--- a/.github/workflows/update-readme-deps.yml
+++ b/.github/workflows/update-readme-deps.yml
@@ -1,0 +1,86 @@
+name: Update README dependencies
+
+# Keeps the Appodeal dependency lists in README.md in sync with the live
+# Dependencies Wizard API (URL from the APPODEAL_API_URL repository variable).
+# The SDK version comes from pubspec.yaml, so a version bump (push) refreshes the
+# lists; the daily schedule catches adapter-version changes published between releases.
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - 'pubspec.yaml'
+      - 'scripts/update-readme-deps.mjs'
+  schedule:
+    # Daily at 06:00 UTC.
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-readme-deps
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Regenerate README dependency lists
+        # URL comes only from the APPODEAL_API_URL repository variable
+        # (Settings → Secrets and variables → Actions → Variables). No hardcoded fallback —
+        # if the variable is unset the script fails loudly.
+        env:
+          APPODEAL_API_URL: ${{ vars.APPODEAL_API_URL }}
+        run: node scripts/update-readme-deps.mjs
+
+      - name: Create PR if README changed
+        # main is protected (changes must go through a PR), so the bot opens a PR as
+        # github-actions[bot]. A different identity (the App below) approves and merges it.
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet -- README.md; then
+            echo "README dependencies already up to date."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BRANCH="chore/update-readme-deps-${{ github.run_id }}-${{ github.run_attempt }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
+          git add README.md
+          git commit -m "chore: sync README dependency lists from Wizard API"
+          git push origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: sync README dependency lists from Wizard API" \
+            --body "Automated update from the Appodeal Dependencies Wizard API."
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Generate App token for approval
+        # A second identity is required: github-actions[bot] (the PR author) cannot approve
+        # its own PR. The GitHub App acts as the reviewer whose approval branch protection counts.
+        if: steps.pr.outputs.created == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Approve and merge PR
+        if: steps.pr.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr review "${{ steps.pr.outputs.branch }}" --approve
+          gh pr merge "${{ steps.pr.outputs.branch }}" --squash --delete-branch

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ $ flutter pub get
 1. Go to `ios/` folder and open *Podfile*
 2. Add Appodeal adapters. Add pods into `./ios/Podfile`:
 
+<!-- appodeal-deps:ios:start -->
 ```ruby
 source 'https://cdn.cocoapods.org'
 source 'https://github.com/appodeal/CocoaPods.git'
@@ -97,6 +98,7 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 ```
+<!-- appodeal-deps:ios:end -->
 
 > [!TIP]
 > Use the [Appodeal Dependencies Wizard](https://docs.appodeal.com/ios/advanced/configure-mediated-networks) to configure mediated networks and generate an always up-to-date dependency list for your Podfile.
@@ -175,6 +177,7 @@ To improve ad performance the following entries should be added:
 
 Add dependencies into `build.gradle` (module: app)
 
+<!-- appodeal-deps:android:start -->
 ``` groovy
 dependencies {
     // ... other project dependencies
@@ -185,6 +188,7 @@ dependencies {
     // https://docs.appodeal.com/android/advanced/configure-mediated-networks
 }
 ```
+<!-- appodeal-deps:android:end -->
 
 Add repository into `build.gradle` (module: project)
 

--- a/README.md
+++ b/README.md
@@ -75,27 +75,109 @@ $ flutter pub get
 
 <!-- appodeal-deps:ios:start -->
 ```ruby
-source 'https://cdn.cocoapods.org'
+platform :ios, '15.0'
+
 source 'https://github.com/appodeal/CocoaPods.git'
 source 'https://github.com/bidon-io/CocoaPods-Specs.git'
-
-platform :ios, '13.0'
+source 'https://cdn.cocoapods.org'
 
 use_frameworks!
 
 def appodeal
-   pod 'Appodeal', '4.1.0'
-   # Add adapter pods here.
-   # Use the Appodeal Dependencies Wizard to generate an up-to-date list:
-   # https://docs.appodeal.com/ios/advanced/configure-mediated-networks
+    pod 'Appodeal', '4.1.0'
+    # AppLovin MAX
+    pod 'AppLovinMediationAmazonAdMarketplaceAdapter', '5.3.2.0'
+    pod 'AppLovinMediationBidMachineAdapter', '3.6.1.0.0'
+    pod 'AppLovinMediationBigoAdsAdapter', '5.0.0.0'
+    pod 'AppLovinMediationByteDanceAdapter', '7.7.0.7.0'
+    pod 'AppLovinMediationChartboostAdapter', '9.10.1.0'
+    pod 'AppLovinMediationFacebookAdapter', '6.20.1.0'
+    pod 'AppLovinMediationFyberAdapter', '8.4.1.0'
+    pod 'AppLovinMediationGoogleAdManagerAdapter', '12.13.0.0'
+    pod 'AppLovinMediationGoogleAdapter', '12.13.0.0'
+    pod 'AppLovinMediationInMobiAdapter', '11.1.0.0'
+    pod 'AppLovinMediationIronSourceAdapter', '9.1.0.0.0'
+    pod 'AppLovinMediationMintegralAdapter', '7.7.9.0.0'
+    pod 'AppLovinMediationMobileFuseAdapter', '1.9.3.0'
+    pod 'AppLovinMediationMolocoAdapter', '4.1.0.0'
+    pod 'AppLovinMediationMyTargetAdapter', '5.36.2.0'
+    pod 'AppLovinMediationOguryPresageAdapter', '5.1.1.0'
+    pod 'AppLovinMediationPubMaticAdapter', '4.10.0.0'
+    pod 'AppLovinMediationSmaatoAdapter', '23.1.0.0'
+    pod 'AppLovinMediationUnityAdsAdapter', '4.16.3.0'
+    pod 'AppLovinMediationVerveAdapter', '3.8.1.0'
+    pod 'AppLovinMediationVungleAdapter', '7.6.2.0'
+    pod 'AppLovinMediationYandexAdapter', '7.17.0.0'
+    # Level Play
+    pod 'IronSourceAdMobAdapter', '5.3.0.0'
+    pod 'IronSourceAppLovinAdapter', '5.3.0.0'
+    pod 'IronSourceBidMachineAdapter', '5.5.0.0'
+    pod 'IronSourceBigoAdapter', '5.1.0.0'
+    pod 'IronSourceFacebookAdapter', '5.0.0.0'
+    pod 'IronSourceFyberAdapter', '5.2.0.0'
+    pod 'IronSourceInMobiAdapter', '5.3.0.0'
+    pod 'IronSourceMintegralAdapter', '5.1.0.0'
+    pod 'IronSourceMobileFuseAdapter', '5.0.0.0'
+    pod 'IronSourceMolocoAdapter', '5.2.0.0'
+    pod 'IronSourceMyTargetAdapter', '5.3.0.0'
+    pod 'IronSourceOguryAdapter', '5.0.0.0'
+    pod 'IronSourcePangleAdapter', '5.5.0.0'
+    pod 'IronSourceSmaatoAdapter', '5.2.0.0'
+    pod 'IronSourceUnityAdsAdapter', '5.2.0.0'
+    pod 'IronSourceVerveAdapter', '5.5.0.0'
+    pod 'IronSourceVungleAdapter', '5.3.0.0'
+    # Bidon
+    pod 'BidonAdapterAmazon', '5.3.2.0'
+    pod 'BidonAdapterAppLovin', '13.5.1.0'
+    pod 'BidonAdapterBidMachine', '3.6.1.1'
+    pod 'BidonAdapterBigoAds', '5.0.0.0'
+    pod 'BidonAdapterChartboost', '9.10.1.0'
+    pod 'BidonAdapterDTExchange', '8.4.1.0'
+    pod 'BidonAdapterInMobi', '11.1.0.0'
+    pod 'BidonAdapterIronSource', '9.1.0.0.0'
+    pod 'BidonAdapterMetaAudienceNetwork', '6.20.1.0'
+    pod 'BidonAdapterMintegral', '7.7.9.0'
+    pod 'BidonAdapterMobileFuse', '1.9.3.0'
+    pod 'BidonAdapterMoloco', '4.1.0.0'
+    pod 'BidonAdapterMyTarget', '5.36.2.0'
+    pod 'BidonAdapterStartIo', '4.13.0.0'
+    pod 'BidonAdapterTaurusX', '1.15.0.0'
+    pod 'BidonAdapterUnityAds', '4.16.3.0'
+    pod 'BidonAdapterVungle', '7.6.2.0'
+    pod 'BidonAdapterYandex', '7.17.0.0'
+    pod 'BidonAdapterZmaticoo', '1.5.6.0'
+    # Appodeal
+    pod 'AppodealAdjustAdapter', '5.4.6.1'
+    pod 'AppodealAmazonAdapter', '5.3.2.0'
+    pod 'AppodealAppLovinAdapter', '13.5.1.0'
+    pod 'AppodealAppLovinMAXAdapter', '13.5.1.1'
+    pod 'AppodealAppsFlyerAdapter', '6.17.7.1'
+    pod 'AppodealBidMachineAdapter', '3.6.1.0'
+    pod 'AppodealBidonAdapter', '0.14.0.1'
+    pod 'AppodealBigoAdsAdapter', '5.0.0.0'
+    pod 'AppodealDTExchangeAdapter', '8.4.1.0'
+    pod 'AppodealFacebookAdapter', '18.0.1.0'
+    pod 'AppodealFirebaseAdapter', '12.4.0.1'
+    pod 'AppodealGoogleAdMobAdapter', '12.13.0.0'
+    pod 'AppodealIABAdapter', '3.4.7.0'
+    pod 'AppodealInMobiAdapter', '11.1.0.0'
+    pod 'AppodealIronSourceAdapter', '9.1.0.0.0'
+    pod 'AppodealLevelPlayAdapter', '9.1.0.0.0'
+    pod 'AppodealMetaAudienceNetworkAdapter', '6.20.1.0'
+    pod 'AppodealMintegralAdapter', '7.7.9.0'
+    pod 'AppodealMyTargetAdapter', '5.36.2.0'
+    pod 'AppodealSentryAdapter', '8.57.2.1'
+    pod 'AppodealUnityAdapter', '4.16.3.0'
+    pod 'AppodealVungleAdapter', '7.6.2.0'
+    pod 'AppodealYandexAdapter', '7.17.0.1'
 end
 
-target 'Runner' do
-  use_frameworks!
-  use_modular_headers!
-  appodeal
+target 'Sample' do
+    project 'Sample/Sample.xcodeproj'
+    appodeal
+    use_modular_headers!
 
-  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+    flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 ```
 <!-- appodeal-deps:ios:end -->
@@ -180,12 +262,109 @@ Add dependencies into `build.gradle` (module: app)
 <!-- appodeal-deps:android:start -->
 ``` groovy
 dependencies {
-    // ... other project dependencies
-    // Appodeal SDK 4.1.0
-    implementation("com.appodeal.ads.sdk:core:4.1.0")
-    // Add adapter dependencies here.
-    // Use the Appodeal Dependencies Wizard to generate an up-to-date list:
-    // https://docs.appodeal.com/android/advanced/configure-mediated-networks
+    implementation "com.appodeal.ads.sdk:core:4.1.0"
+    // Bidon
+    implementation "org.bidon:amazon-adapter:11.3.0.0"
+    implementation "org.bidon:applovin-adapter:13.5.1.0"
+    implementation "org.bidon:bidmachine-adapter:3.7.1.0"
+    implementation "org.bidon:bigoads-adapter:5.6.2.0"
+    implementation "org.bidon:chartboost-adapter:9.10.2.0"
+    implementation "org.bidon:dtexchange-adapter:8.4.1.0"
+    implementation "org.bidon:inmobi-adapter:11.1.0.0"
+    implementation "org.bidon:ironsource-adapter:9.1.0.0"
+    implementation "org.bidon:meta-adapter:6.21.0.0"
+    implementation "org.bidon:mintegral-adapter:17.1.61.0"
+    implementation "org.bidon:mobilefuse-adapter:1.9.3.0"
+    implementation "org.bidon:moloco-adapter:4.3.1.0"
+    implementation "org.bidon:startio-adapter:5.2.4.1"
+    implementation "org.bidon:taurusx-adapter:1.12.2.0"
+    implementation "org.bidon:unityads-adapter:4.17.0.0"
+    implementation "org.bidon:vkads-adapter:5.47.1.0"
+    implementation "org.bidon:vungle-adapter:7.6.1.0"
+    implementation "org.bidon:yandex-adapter:7.17.0.0"
+    implementation "org.bidon:zmaticoo-adapter:2.0.5.1.0"
+    // AppLovin MAX
+    implementation "com.applovin.mediation:amazon-tam-adapter:11.3.0.0"
+    implementation "com.applovin.mediation:bidmachine-adapter:3.7.1.0"
+    implementation "com.applovin.mediation:bigoads-adapter:5.6.2.0"
+    implementation "com.applovin.mediation:bytedance-adapter:7.7.0.2.0"
+    implementation "com.applovin.mediation:chartboost-adapter:9.10.2.0"
+    implementation "com.applovin.mediation:facebook-adapter:6.21.0.0"
+    implementation "com.applovin.mediation:fyber-adapter:8.4.1.0"
+    implementation "com.applovin.mediation:google-ad-manager-adapter:24.7.0.0"
+    implementation "com.applovin.mediation:google-adapter:24.7.0.0"
+    implementation "com.applovin.mediation:inmobi-adapter:11.1.0.0"
+    implementation "com.applovin.mediation:ironsource-adapter:9.1.0.0.0"
+    implementation "com.applovin.mediation:mintegral-adapter:17.1.61.0"
+    implementation "com.applovin.mediation:mobilefuse-adapter:1.9.3.0"
+    implementation "com.applovin.mediation:moloco-adapter:4.3.1.0"
+    implementation "com.applovin.mediation:mytarget-adapter:5.47.1.0"
+    implementation "com.applovin.mediation:ogury-presage-adapter:6.2.0.0"
+    implementation "com.applovin.mediation:pubmatic-adapter:4.10.0.0"
+    implementation "com.applovin.mediation:smaato-adapter:22.7.2.3"
+    implementation "com.applovin.mediation:unityads-adapter:4.17.0.0"
+    implementation "com.applovin.mediation:verve-adapter:3.7.1.0"
+    implementation "com.applovin.mediation:vungle-adapter:7.6.1.0"
+    implementation "com.applovin.mediation:yandex-adapter:7.17.0.0"
+    // Level Play
+    implementation "com.unity3d.ads-mediation:admob-adapter:5.2.0"
+    implementation "com.unity3d.ads-mediation:applovin-adapter:5.2.0"
+    implementation "com.unity3d.ads-mediation:bidmachine-adapter:5.7.0"
+    implementation "com.unity3d.ads-mediation:bigo-adapter:5.3.0"
+    implementation "com.unity3d.ads-mediation:facebook-adapter:5.2.0"
+    implementation "com.unity3d.ads-mediation:fyber-adapter:5.2.0"
+    implementation "com.unity3d.ads-mediation:inmobi-adapter:5.3.0"
+    implementation "com.unity3d.ads-mediation:mintegral-adapter:5.14.0"
+    implementation "com.unity3d.ads-mediation:mobilefuse-adapter:5.1.0"
+    implementation "com.unity3d.ads-mediation:moloco-adapter:5.5.0"
+    implementation "com.unity3d.ads-mediation:mytarget-adapter:5.4.0"
+    implementation "com.unity3d.ads-mediation:ogury-adapter:5.2.0"
+    implementation "com.unity3d.ads-mediation:pangle-adapter:5.3.0"
+    implementation "com.unity3d.ads-mediation:smaato-adapter:5.0.0"
+    implementation "com.unity3d.ads-mediation:unityads-adapter:5.6.0"
+    implementation "com.unity3d.ads-mediation:verve-adapter:5.2.0"
+    implementation "com.unity3d.ads-mediation:vungle-adapter:5.4.0"
+    // Appodeal
+    implementation "com.appodeal.ads.sdk.adapters:adjust:5.4.6.1"
+    implementation "com.appodeal.ads.sdk.adapters:admob:24.7.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:amazon:11.3.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:applovin:13.5.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:applovin_max:13.5.1.1"
+    implementation "com.appodeal.ads.sdk.adapters:appsflyer:6.17.3.1"
+    implementation "com.appodeal.ads.sdk.adapters:bidmachine:3.7.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:bidon:0.13.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:bigo_ads:5.6.2.0"
+    implementation "com.appodeal.ads.sdk.adapters:chartboost:9.10.2.0"
+    implementation "com.appodeal.ads.sdk.adapters:dt_exchange:8.4.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:facebook_analytics:18.0.3.0"
+    implementation "com.appodeal.ads.sdk.adapters:firebase:23.0.0.1"
+    implementation "com.appodeal.ads.sdk.adapters:iab:1.8.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:inmobi:11.1.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:ironsource:9.1.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:level_play:9.1.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:meta:6.21.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:mintegral:17.1.61.0"
+    implementation "com.appodeal.ads.sdk.adapters:mobilefuse:1.9.3.0"
+    implementation "com.appodeal.ads.sdk.adapters:moloco:4.3.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:my_target:5.47.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:ogury:6.2.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:pangle:7.7.0.2.0"
+    implementation "com.appodeal.ads.sdk.adapters:pubmatic:4.10.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:sentry_analytics:8.26.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:smaato:22.7.2.0"
+    implementation "com.appodeal.ads.sdk.adapters:startio:5.2.4.0"
+    implementation "com.appodeal.ads.sdk.adapters:taurusx:1.12.2.0"
+    implementation "com.appodeal.ads.sdk.adapters:unity_ads:4.17.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:verve:3.7.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:vungle:7.6.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:yandex:7.17.0.0"
+    // BidMachine
+    implementation "io.bidmachine:ads.networks.amazon:11.3.0.2"
+    implementation "io.bidmachine:ads.networks.meta_audience:6.21.0.1"
+    implementation "io.bidmachine:ads.networks.mintegral:17.1.61.1"
+    implementation "io.bidmachine:ads.networks.my_target:5.47.1.2"
+    implementation "io.bidmachine:ads.networks.pangle:7.7.0.2.2"
+    implementation "io.bidmachine:ads.networks.vungle:7.6.1.2"
 }
 ```
 <!-- appodeal-deps:android:end -->

--- a/scripts/update-readme-deps.mjs
+++ b/scripts/update-readme-deps.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // Updates the README.md dependency blocks from the Appodeal Wizard API.
-// API output is used verbatim; only the iOS Podfile target gets Flutter linking injected.
+// API output is used verbatim; the iOS Podfile target additionally gets
+// `use_modular_headers!` and the Flutter autolinking call injected.
 
 import { readFile, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
@@ -78,9 +79,10 @@ async function fetchDependencyBlock(platform, version, lang) {
   return (await depsRes.text()).replace(/\t/g, '    ');
 }
 
-/** Wrap rendered code in a fenced Markdown block. */
-function fenced(lang, body) {
-  return `${lang}\n${body.trimEnd()}\n\`\`\``;
+/** Wrap rendered code in a fenced Markdown block. `fence` is the full opening fence
+ *  including backticks, e.g. "``` groovy" or "```ruby". */
+function fenced(fence, body) {
+  return `${fence}\n${body.trimEnd()}\n\`\`\``;
 }
 
 /**
@@ -98,10 +100,10 @@ function androidDependenciesOnly(text) {
 }
 
 /**
- * Inject the Flutter linking line into the iOS Podfile target. The Wizard renders a plain
- * native target (`target 'Sample' do ... end`); Flutter apps additionally need the
- * autolinking call, otherwise the copied Podfile won't build. Everything else from the
- * API response is left untouched.
+ * Adapt the Wizard's iOS Podfile target for Flutter. The Wizard renders a plain native
+ * target (`target 'Sample' do ... end`); Flutter apps additionally need `use_modular_headers!`
+ * and the `flutter_install_all_ios_pods` autolinking call, otherwise the copied Podfile
+ * won't build. Everything else from the API response is left untouched.
  */
 function addFlutterLinking(podfile) {
   const linking = [
@@ -142,9 +144,9 @@ async function main() {
   const version = await getVersion();
   console.log(`Updating README dependency lists for Appodeal SDK ${version}`);
 
-  // android uses kts (`kt`) verbatim; ios ignores the language, returns Ruby, and gets
-  // the Flutter linking injected into its target.
-  const android = androidDependenciesOnly(await fetchDependencyBlock('android', version, 'kt'));
+  // android uses the Groovy DSL (matches the README's `build.gradle` / groovy fence); ios
+  // ignores the language, returns Ruby, and gets the Flutter linking injected into its target.
+  const android = androidDependenciesOnly(await fetchDependencyBlock('android', version, 'groovy'));
   const ios = addFlutterLinking(await fetchDependencyBlock('ios', version));
 
   let readme = await readFile(README, 'utf8');

--- a/scripts/update-readme-deps.mjs
+++ b/scripts/update-readme-deps.mjs
@@ -27,7 +27,9 @@ async function getVersion() {
   const pubspec = await readFile(join(ROOT, 'pubspec.yaml'), 'utf8');
   const match = pubspec.match(/^version:\s*(.+)$/m);
   if (!match) throw new Error('pubspec.yaml has no "version" field');
-  return match[1].trim();
+  // Strip any build metadata (e.g. `4.1.0+4` -> `4.1.0`): the Wizard API endpoints
+  // expect a plain SDK version, a `+...` suffix would break the request path.
+  return match[1].trim().split('+')[0];
 }
 
 async function apiFetch(path, options = {}) {

--- a/scripts/update-readme-deps.mjs
+++ b/scripts/update-readme-deps.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+// Updates the README.md dependency blocks from the Appodeal Wizard API.
+// API output is used verbatim; only the iOS Podfile target gets Flutter linking injected.
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// API base URL — required, supplied via the APPODEAL_API_URL env var (set by the
+// GitHub Action / your shell). No fallback: fail loudly rather than hit a guessed host.
+const API = (() => {
+  const raw = process.env.APPODEAL_API_URL;
+  if (!raw) {
+    throw new Error('APPODEAL_API_URL env var is required');
+  }
+  return raw.replace(/\/+$/, '');
+})();
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const README = join(ROOT, 'README.md');
+
+// Category codes returned by the /sdks endpoint.
+const CATEGORY_NETWORK = 2;
+const CATEGORY_SERVICE = 3;
+
+/** Read the single source-of-truth version from pubspec.yaml. */
+async function getVersion() {
+  const pubspec = await readFile(join(ROOT, 'pubspec.yaml'), 'utf8');
+  const match = pubspec.match(/^version:\s*(.+)$/m);
+  if (!match) throw new Error('pubspec.yaml has no "version" field');
+  return match[1].trim();
+}
+
+async function apiFetch(path, options = {}) {
+  const res = await fetch(`${API}${path}`, {
+    headers: { 'content-type': 'application/json', accept: '*/*' },
+    signal: AbortSignal.timeout(30_000),
+    ...options,
+  });
+  if (!res.ok) {
+    throw new Error(`API ${path} -> HTTP ${res.status} ${res.statusText}`);
+  }
+  return res;
+}
+
+/** Collect every version id from a list of {versions:[{id}]} entries. */
+function collectVersionIds(entries) {
+  return (entries ?? []).flatMap((e) => (e.versions ?? []).map((v) => v.id));
+}
+
+/** Run the 3-step recommended pipeline and return the rendered dependency text. */
+async function fetchDependencyBlock(platform, version, lang) {
+  // Step 1 — recommended mediations.
+  const mediationsRes = await apiFetch(
+    `/v4/${platform}/${version}/mediations?recommended=true`
+  );
+  const mediations = collectVersionIds((await mediationsRes.json()).mediations);
+
+  // Step 2 — recommended sdks for those mediations, split into networks / services.
+  const sdksRes = await apiFetch(`/v4/${platform}/${version}/sdks?recommended=true`, {
+    method: 'POST',
+    body: JSON.stringify({ mediations, networks: [], services: [] }),
+  });
+  const sdks = (await sdksRes.json()).sdks ?? [];
+  const networks = collectVersionIds(sdks.filter((s) => s.category === CATEGORY_NETWORK));
+  const services = collectVersionIds(sdks.filter((s) => s.category === CATEGORY_SERVICE));
+
+  // Step 3 — render. iOS has no language suffix (always Ruby).
+  const path =
+    platform === 'ios'
+      ? `/v4/${platform}/${version}/dependencies`
+      : `/v4/${platform}/${version}/dependencies/${lang}`;
+  const depsRes = await apiFetch(path, {
+    method: 'POST',
+    body: JSON.stringify({ mediations, networks, services }),
+  });
+  return (await depsRes.text()).replace(/\t/g, '    ');
+}
+
+/** Wrap rendered code in a fenced Markdown block. */
+function fenced(lang, body) {
+  return `${lang}\n${body.trimEnd()}\n\`\`\``;
+}
+
+/**
+ * Keep only the `dependencies { ... }` block from the Android response. The Wizard
+ * prepends a `repositories { ... }` block (already documented separately in the README's
+ * "Add repository into build.gradle" section) and a build.gradle label comment, which
+ * would otherwise duplicate the repository setup and mislead readers.
+ */
+function androidDependenciesOnly(text) {
+  const idx = text.search(/^dependencies\s*\{/m);
+  if (idx === -1) {
+    throw new Error('Could not find `dependencies {` in the Android API response');
+  }
+  return text.slice(idx);
+}
+
+/**
+ * Inject the Flutter linking line into the iOS Podfile target. The Wizard renders a plain
+ * native target (`target 'Sample' do ... end`); Flutter apps additionally need the
+ * autolinking call, otherwise the copied Podfile won't build. Everything else from the
+ * API response is left untouched.
+ */
+function addFlutterLinking(podfile) {
+  const linking = [
+    '',
+    '    use_modular_headers!',
+    '',
+    '    flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))',
+  ].join('\n');
+  // The target block is the last one in the response; insert before its closing `end`.
+  const trimmed = podfile.trimEnd();
+  const patched = trimmed.replace(/\n[ \t]*end$/, `${linking}\nend`);
+  if (patched === trimmed) {
+    throw new Error('Could not locate the iOS Podfile target `end` to inject Flutter linking');
+  }
+  return patched;
+}
+
+/**
+ * Replace everything between the HTML-comment markers for `name` with `block`.
+ * Markers live OUTSIDE the fenced code block so they stay invisible in rendered Markdown:
+ *   <!-- appodeal-deps:NAME:start ... -->   ...block...   <!-- appodeal-deps:NAME:end -->
+ */
+function replaceBetweenMarkers(readme, name, block) {
+  const startRe = new RegExp(`<!--\\s*appodeal-deps:${name}:start\\b[^>]*-->`);
+  const endRe = new RegExp(`<!--\\s*appodeal-deps:${name}:end\\s*-->`);
+  const startMatch = readme.match(startRe);
+  if (!startMatch) throw new Error(`Marker appodeal-deps:${name}:start not found in README.md`);
+  const startIdx = startMatch.index + startMatch[0].length;
+
+  const endMatch = readme.slice(startIdx).match(endRe);
+  if (!endMatch) throw new Error(`Marker appodeal-deps:${name}:end not found after start in README.md`);
+  const endIdx = startIdx + endMatch.index;
+
+  return `${readme.slice(0, startIdx)}\n${block}\n${readme.slice(endIdx)}`;
+}
+
+async function main() {
+  const version = await getVersion();
+  console.log(`Updating README dependency lists for Appodeal SDK ${version}`);
+
+  // android uses kts (`kt`) verbatim; ios ignores the language, returns Ruby, and gets
+  // the Flutter linking injected into its target.
+  const android = androidDependenciesOnly(await fetchDependencyBlock('android', version, 'kt'));
+  const ios = addFlutterLinking(await fetchDependencyBlock('ios', version));
+
+  let readme = await readFile(README, 'utf8');
+  readme = replaceBetweenMarkers(readme, 'android', fenced('``` groovy', android));
+  readme = replaceBetweenMarkers(readme, 'ios', fenced('```ruby', ios));
+
+  await writeFile(README, readme, 'utf8');
+  console.log('Done: README dependency blocks updated.');
+}
+
+main().catch((err) => {
+  console.error(`\n✖ ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Ports the README dependency auto-sync feature from [react-native-appodeal](https://github.com/appodeal/react-native-appodeal) (PRs #165–#168) to the Flutter plugin.

## What

- **`scripts/update-readme-deps.mjs`** — fetches recommended mediations/sdks from the Appodeal Dependencies Wizard API and renders the iOS/Android dependency blocks, replacing the content between HTML-comment markers in `README.md`.
  - SDK version source: `pubspec.yaml` (RN used `package.json`).
  - iOS: Wizard output kept verbatim; `flutter_install_all_ios_pods` injected into the Podfile target (RN injects RN autolinking instead).
  - Android: keeps only the `dependencies { }` block — the duplicated `repositories { }` block is dropped (same as RN fix #168), since repos are documented separately.
- **`.github/workflows/update-readme-deps.yml`** — runs on `pubspec.yaml`/script push to `main`, daily at 06:00 UTC, and manual dispatch. Bot opens a PR, a GitHub App approves + squash-merges it.
- **`README.md`** — `appodeal-deps:ios/android` markers added around the dependency fenced blocks.

## ⚠️ Required repo setup before the workflow works

1. **Variable** `APPODEAL_API_URL` = `https://neo-mw-backend.appodeal.com` (Settings → Secrets and variables → Actions → Variables).
2. **Secrets** `APP_ID` + `APP_PRIVATE_KEY` (the same GitHub App used in react-native-appodeal).
3. **Branch protection** on `main` (require PR + review) — so the App-approve+merge flow is meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)