### PR TITLE
Release/4.2.0 (APDM-2676)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 4.2.0
+
+- **Minimum Android API level raised from 23 (Android 6.0) to 24 (Android 7.0)**
+- **Added Privacy Entry Point support (US State Regulations / GDPR re-consent)**: `Appodeal.ConsentForm.getPrivacyOptionsRequirementStatus()` and `Appodeal.ConsentForm.showPrivacyOptionsForm(...)`
+
+### Updated SDKs
+
+- Updated Appodeal iOS SDK to [4.2.0](https://docs.appodeal.com/ios/get-started)
+- Updated Appodeal Android SDK to [4.2.0](https://docs.appodeal.com/android/get-started)
+
 ## 4.1.0
 
 - **Android SDK now uses individual adapter dependencies instead of a single umbrella SDK**

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ source 'https://cdn.cocoapods.org'
 use_frameworks!
 
 def appodeal
-    pod 'Appodeal', '4.1.0'
+    pod 'Appodeal', '4.2.0'
     # AppLovin MAX
     pod 'AppLovinMediationAmazonAdMarketplaceAdapter', '5.3.2.0'
-    pod 'AppLovinMediationBidMachineAdapter', '3.6.1.0.0'
+    pod 'AppLovinMediationBidMachineAdapter', '3.7.1.0.0'
     pod 'AppLovinMediationBigoAdsAdapter', '5.0.0.0'
     pod 'AppLovinMediationByteDanceAdapter', '7.7.0.7.0'
     pod 'AppLovinMediationChartboostAdapter', '9.10.1.0'
@@ -111,7 +111,7 @@ def appodeal
     # Level Play
     pod 'IronSourceAdMobAdapter', '5.3.0.0'
     pod 'IronSourceAppLovinAdapter', '5.3.0.0'
-    pod 'IronSourceBidMachineAdapter', '5.5.0.0'
+    pod 'IronSourceBidMachineAdapter', '5.7.0.0'
     pod 'IronSourceBigoAdapter', '5.1.0.0'
     pod 'IronSourceFacebookAdapter', '5.0.0.0'
     pod 'IronSourceFyberAdapter', '5.2.0.0'
@@ -126,10 +126,34 @@ def appodeal
     pod 'IronSourceUnityAdsAdapter', '5.2.0.0'
     pod 'IronSourceVerveAdapter', '5.5.0.0'
     pod 'IronSourceVungleAdapter', '5.3.0.0'
+    # Appodeal
+    pod 'AppodealAdjustAdapter', '5.4.6.1'
+    pod 'AppodealAmazonAdapter', '5.3.2.0'
+    pod 'AppodealAppLovinAdapter', '13.5.1.0'
+    pod 'AppodealAppLovinMAXAdapter', '13.5.1.1'
+    pod 'AppodealAppsFlyerAdapter', '6.17.7.1'
+    pod 'AppodealBidMachineAdapter', '3.7.1.0'
+    pod 'AppodealBidonAdapter', '0.15.0.0'
+    pod 'AppodealBigoAdsAdapter', '5.0.0.0'
+    pod 'AppodealDTExchangeAdapter', '8.4.1.0'
+    pod 'AppodealFacebookAdapter', '18.0.1.0'
+    pod 'AppodealFirebaseAdapter', '12.4.0.1'
+    pod 'AppodealGoogleAdMobAdapter', '12.13.0.0'
+    pod 'AppodealIABAdapter', '3.5.0.0'
+    pod 'AppodealInMobiAdapter', '11.1.0.0'
+    pod 'AppodealIronSourceAdapter', '9.1.0.0.0'
+    pod 'AppodealLevelPlayAdapter', '9.1.0.0.0'
+    pod 'AppodealMetaAudienceNetworkAdapter', '6.20.1.0'
+    pod 'AppodealMintegralAdapter', '7.7.9.0'
+    pod 'AppodealMyTargetAdapter', '5.36.2.0'
+    pod 'AppodealSentryAdapter', '8.57.2.1'
+    pod 'AppodealUnityAdapter', '4.16.3.0'
+    pod 'AppodealVungleAdapter', '7.6.2.0'
+    pod 'AppodealYandexAdapter', '7.17.0.1'
     # Bidon
     pod 'BidonAdapterAmazon', '5.3.2.0'
     pod 'BidonAdapterAppLovin', '13.5.1.0'
-    pod 'BidonAdapterBidMachine', '3.6.1.1'
+    pod 'BidonAdapterBidMachine', '3.7.1.1'
     pod 'BidonAdapterBigoAds', '5.0.0.0'
     pod 'BidonAdapterChartboost', '9.10.1.0'
     pod 'BidonAdapterDTExchange', '8.4.1.0'
@@ -146,30 +170,6 @@ def appodeal
     pod 'BidonAdapterVungle', '7.6.2.0'
     pod 'BidonAdapterYandex', '7.17.0.0'
     pod 'BidonAdapterZmaticoo', '2.2.0.0'
-    # Appodeal
-    pod 'AppodealAdjustAdapter', '5.4.6.1'
-    pod 'AppodealAmazonAdapter', '5.3.2.0'
-    pod 'AppodealAppLovinAdapter', '13.5.1.0'
-    pod 'AppodealAppLovinMAXAdapter', '13.5.1.1'
-    pod 'AppodealAppsFlyerAdapter', '6.17.7.1'
-    pod 'AppodealBidMachineAdapter', '3.6.1.0'
-    pod 'AppodealBidonAdapter', '0.14.0.1'
-    pod 'AppodealBigoAdsAdapter', '5.0.0.0'
-    pod 'AppodealDTExchangeAdapter', '8.4.1.0'
-    pod 'AppodealFacebookAdapter', '18.0.1.0'
-    pod 'AppodealFirebaseAdapter', '12.4.0.1'
-    pod 'AppodealGoogleAdMobAdapter', '12.13.0.0'
-    pod 'AppodealIABAdapter', '3.4.7.0'
-    pod 'AppodealInMobiAdapter', '11.1.0.0'
-    pod 'AppodealIronSourceAdapter', '9.1.0.0.0'
-    pod 'AppodealLevelPlayAdapter', '9.1.0.0.0'
-    pod 'AppodealMetaAudienceNetworkAdapter', '6.20.1.0'
-    pod 'AppodealMintegralAdapter', '7.7.9.0'
-    pod 'AppodealMyTargetAdapter', '5.36.2.0'
-    pod 'AppodealSentryAdapter', '8.57.2.1'
-    pod 'AppodealUnityAdapter', '4.16.3.0'
-    pod 'AppodealVungleAdapter', '7.6.2.0'
-    pod 'AppodealYandexAdapter', '7.17.0.1'
 end
 
 target 'Sample' do
@@ -262,32 +262,12 @@ Add dependencies into `build.gradle` (module: app)
 <!-- appodeal-deps:android:start -->
 ``` groovy
 dependencies {
-    implementation "com.appodeal.ads.sdk:core:4.1.0"
-    // Bidon
-    implementation "org.bidon:amazon-adapter:11.3.0.0"
-    implementation "org.bidon:applovin-adapter:13.5.1.0"
-    implementation "org.bidon:bidmachine-adapter:3.7.1.0"
-    implementation "org.bidon:bigoads-adapter:5.6.2.0"
-    implementation "org.bidon:chartboost-adapter:9.10.2.0"
-    implementation "org.bidon:dtexchange-adapter:8.4.1.0"
-    implementation "org.bidon:inmobi-adapter:11.1.0.0"
-    implementation "org.bidon:ironsource-adapter:9.1.0.0"
-    implementation "org.bidon:meta-adapter:6.21.0.0"
-    implementation "org.bidon:mintegral-adapter:17.1.61.0"
-    implementation "org.bidon:mobilefuse-adapter:1.9.3.0"
-    implementation "org.bidon:moloco-adapter:4.3.1.0"
-    implementation "org.bidon:startio-adapter:5.2.4.1"
-    implementation "org.bidon:taurusx-adapter:1.12.2.0"
-    implementation "org.bidon:unityads-adapter:4.17.0.0"
-    implementation "org.bidon:vkads-adapter:5.47.1.0"
-    implementation "org.bidon:vungle-adapter:7.6.1.0"
-    implementation "org.bidon:yandex-adapter:7.17.0.0"
-    implementation "org.bidon:zmaticoo-adapter:2.0.6.0.0"
+    implementation "com.appodeal.ads.sdk:core:4.2.0"
     // AppLovin MAX
     implementation "com.applovin.mediation:amazon-tam-adapter:11.3.0.0"
     implementation "com.applovin.mediation:bidmachine-adapter:3.7.1.0"
     implementation "com.applovin.mediation:bigoads-adapter:5.6.2.0"
-    implementation "com.applovin.mediation:bytedance-adapter:7.7.0.2.0"
+    implementation "com.applovin.mediation:bytedance-adapter:8.1.0.3.0"
     implementation "com.applovin.mediation:chartboost-adapter:9.10.2.0"
     implementation "com.applovin.mediation:facebook-adapter:6.21.0.0"
     implementation "com.applovin.mediation:fyber-adapter:8.4.1.0"
@@ -319,20 +299,46 @@ dependencies {
     implementation "com.unity3d.ads-mediation:moloco-adapter:5.5.0"
     implementation "com.unity3d.ads-mediation:mytarget-adapter:5.5.0"
     implementation "com.unity3d.ads-mediation:ogury-adapter:5.2.0"
-    implementation "com.unity3d.ads-mediation:pangle-adapter:5.3.0"
+    implementation "com.unity3d.ads-mediation:pangle-adapter:5.18.0"
     implementation "com.unity3d.ads-mediation:smaato-adapter:5.0.0"
     implementation "com.unity3d.ads-mediation:unityads-adapter:5.6.0"
     implementation "com.unity3d.ads-mediation:verve-adapter:5.2.0"
     implementation "com.unity3d.ads-mediation:vungle-adapter:5.4.0"
+    // BidMachine
+    implementation "io.bidmachine:ads.networks.amazon:11.3.0.2"
+    implementation "io.bidmachine:ads.networks.meta_audience:6.21.0.1"
+    implementation "io.bidmachine:ads.networks.mintegral:17.1.61.1"
+    implementation "io.bidmachine:ads.networks.my_target:5.47.1.2"
+    implementation "io.bidmachine:ads.networks.vungle:7.6.1.2"
+    // Bidon
+    implementation "org.bidon:amazon-adapter:11.3.0.0"
+    implementation "org.bidon:applovin-adapter:13.5.1.0"
+    implementation "org.bidon:bidmachine-adapter:3.7.1.0"
+    implementation "org.bidon:bigoads-adapter:5.6.2.0"
+    implementation "org.bidon:chartboost-adapter:9.10.2.0"
+    implementation "org.bidon:dtexchange-adapter:8.4.1.0"
+    implementation "org.bidon:inmobi-adapter:11.1.0.0"
+    implementation "org.bidon:ironsource-adapter:9.1.0.0"
+    implementation "org.bidon:meta-adapter:6.21.0.0"
+    implementation "org.bidon:mintegral-adapter:17.1.61.0"
+    implementation "org.bidon:mobilefuse-adapter:1.9.3.0"
+    implementation "org.bidon:moloco-adapter:4.3.1.0"
+    implementation "org.bidon:startio-adapter:5.2.4.1"
+    implementation "org.bidon:taurusx-adapter:1.12.2.0"
+    implementation "org.bidon:unityads-adapter:4.17.0.0"
+    implementation "org.bidon:vkads-adapter:5.47.1.0"
+    implementation "org.bidon:vungle-adapter:7.6.1.0"
+    implementation "org.bidon:yandex-adapter:7.17.0.0"
+    implementation "org.bidon:zmaticoo-adapter:2.0.6.0.0"
     // Appodeal
     implementation "com.appodeal.ads.sdk.adapters:adjust:5.4.6.1"
     implementation "com.appodeal.ads.sdk.adapters:admob:24.7.0.0"
     implementation "com.appodeal.ads.sdk.adapters:amazon:11.3.0.0"
     implementation "com.appodeal.ads.sdk.adapters:applovin:13.5.1.0"
     implementation "com.appodeal.ads.sdk.adapters:applovin_max:13.5.1.1"
-    implementation "com.appodeal.ads.sdk.adapters:appsflyer:6.17.3.1"
+    implementation "com.appodeal.ads.sdk.adapters:appsflyer:6.18.0.1"
     implementation "com.appodeal.ads.sdk.adapters:bidmachine:3.7.1.0"
-    implementation "com.appodeal.ads.sdk.adapters:bidon:0.13.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:bidon:0.14.0.0"
     implementation "com.appodeal.ads.sdk.adapters:bigo_ads:5.6.2.0"
     implementation "com.appodeal.ads.sdk.adapters:chartboost:9.10.2.0"
     implementation "com.appodeal.ads.sdk.adapters:dt_exchange:8.4.1.0"
@@ -348,7 +354,6 @@ dependencies {
     implementation "com.appodeal.ads.sdk.adapters:moloco:4.3.1.0"
     implementation "com.appodeal.ads.sdk.adapters:my_target:5.47.1.0"
     implementation "com.appodeal.ads.sdk.adapters:ogury:6.2.0.0"
-    implementation "com.appodeal.ads.sdk.adapters:pangle:7.7.0.2.0"
     implementation "com.appodeal.ads.sdk.adapters:pubmatic:4.10.0.0"
     implementation "com.appodeal.ads.sdk.adapters:sentry_analytics:8.26.0.0"
     implementation "com.appodeal.ads.sdk.adapters:smaato:22.7.2.0"
@@ -358,13 +363,6 @@ dependencies {
     implementation "com.appodeal.ads.sdk.adapters:verve:3.7.1.0"
     implementation "com.appodeal.ads.sdk.adapters:vungle:7.6.1.0"
     implementation "com.appodeal.ads.sdk.adapters:yandex:7.17.0.0"
-    // BidMachine
-    implementation "io.bidmachine:ads.networks.amazon:11.3.0.2"
-    implementation "io.bidmachine:ads.networks.meta_audience:6.21.0.1"
-    implementation "io.bidmachine:ads.networks.mintegral:17.1.61.1"
-    implementation "io.bidmachine:ads.networks.my_target:5.47.1.2"
-    implementation "io.bidmachine:ads.networks.pangle:7.7.0.2.2"
-    implementation "io.bidmachine:ads.networks.vungle:7.6.1.2"
 }
 ```
 <!-- appodeal-deps:android:end -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Official Appodeal Flutter Plugin for your Flutter application.
 
-## Appodeal SDK 4.1.0
+## Appodeal SDK 4.2.0
 
 - **Google CMP and TCF v2 Support**
   - To enhance the relevance of ads for your users and comply with regulations like GDPR and CCPA,
@@ -53,7 +53,7 @@ Add the dependency to the `pubspec.yaml` file in your project:
 
 ```yaml
 dependencies:
-  stack_appodeal_flutter: 4.1.0
+  stack_appodeal_flutter: 4.2.0
 ```
 
 Install the plugin by running the command below in the terminal:

--- a/README.md
+++ b/README.md
@@ -187,6 +187,15 @@ end
 
 > Note: Appodeal requires to use `use_frameworks!`. You need to remove Flipper dependency from Podfile and AppDelegate.
 
+> [!NOTE]
+> The Appodeal dependency list pulls pods from three sources (`appodeal`, `bidon-io`, `cdn.cocoapods.org`). Because some pods are published in more than one of them, CocoaPods prints a `Found multiple specifications` warning for each. Add the following to the top of your `Podfile` to silence those warnings and speed up project generation on this large dependency graph:
+>
+> ```ruby
+> install! 'cocoapods',
+>   :deterministic_uuids => false,
+>   :warn_for_multiple_pod_sources => false
+> ```
+
 3. Call `pod install`
 4. Open `.xcworkspace`
 5. Configure `Info.plist`.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,11 +30,11 @@ android {
         namespace 'com.appodeal.appodeal_flutter'
     }
 
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
-        minSdk 23
-        targetSdk 35
+        minSdk 24
+        targetSdk 36
     }
 
     compileOptions {
@@ -53,7 +53,7 @@ android {
 
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:$kotlin_version"))
-    // Appodeal SDK 4.1.0
-    implementation 'com.appodeal.ads.sdk:core:4.1.0'
+    // Appodeal SDK 4.2.0
+    implementation 'com.appodeal.ads.sdk:core:4.2.0'
     implementation 'com.appodeal.ads.sdk.adapters:iab:1.8.1.0'
 }

--- a/android/src/main/kotlin/com/appodeal/appodeal_flutter/AppodealConsentManager.kt
+++ b/android/src/main/kotlin/com/appodeal/appodeal_flutter/AppodealConsentManager.kt
@@ -6,6 +6,8 @@ import com.appodeal.consent.ConsentInfoUpdateCallback
 import com.appodeal.consent.ConsentManager
 import com.appodeal.consent.ConsentManagerError
 import com.appodeal.consent.ConsentUpdateRequestParameters
+import com.appodeal.consent.OnConsentFormDismissedListener
+import com.appodeal.consent.PrivacyOptionsRequirementStatus
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -28,6 +30,8 @@ internal class AppodealConsentManager(
             "show" -> show(call, result)
             "loadAndShowIfRequired" -> loadAndShowIfRequired(call, result)
             "revoke" -> revoke(call, result)
+            "getPrivacyOptionsRequirementStatus" -> getPrivacyOptionsRequirementStatus(call, result)
+            "showPrivacyOptionsForm" -> showPrivacyOptionsForm(call, result)
             else -> result.notImplemented()
         }
     }
@@ -121,6 +125,31 @@ internal class AppodealConsentManager(
 
     private fun revoke(call: MethodCall, result: MethodChannel.Result) {
         ConsentManager.revoke(flutterPlugin.context)
+        result.success(null)
+    }
+
+    private fun getPrivacyOptionsRequirementStatus(call: MethodCall, result: MethodChannel.Result) {
+        // Normalized to match the Dart PrivacyOptionsRequirementStatus enum and the iOS side:
+        // 0 = unknown, 1 = required, 2 = notRequired.
+        val normalized = when (ConsentManager.getPrivacyOptionsRequirementStatus()) {
+            PrivacyOptionsRequirementStatus.Required -> 1
+            PrivacyOptionsRequirementStatus.NotRequired -> 2
+            else -> 0
+        }
+        result.success(normalized)
+    }
+
+    private fun showPrivacyOptionsForm(call: MethodCall, result: MethodChannel.Result) {
+        val activity = flutterPlugin.activity
+        ConsentManager.showPrivacyOptionsForm(
+            activity,
+            object : OnConsentFormDismissedListener {
+                override fun onConsentFormDismissed(error: ConsentManagerError?) {
+                    val invokeArgs = error?.let { mapOf("error" to it.localizedMessage) }
+                    adChannel.invokeMethod("onConsentFormDismissed", invokeArgs)
+                }
+            }
+        )
         result.success(null)
     }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -24,12 +24,12 @@ if (flutterVersionName == null) {
 }
 
 android {
-    compileSdk 35
+    compileSdk 36
     namespace 'com.appodeal.appodeal_flutter_example'
 
     defaultConfig {
-        minSdk 23
-        targetSdk 35
+        minSdk 24
+        targetSdk 36
         applicationId "com.appodealstack.demo"
         versionName flutterVersionName
         versionCode flutterVersionCode.toInteger()
@@ -60,106 +60,105 @@ flutter {
 }
 
 dependencies {
-    implementation("com.appodeal.ads.sdk:core:4.1.0")
-    // Bidon
-    implementation("org.bidon:amazon-adapter:11.1.1.0")
-    implementation("org.bidon:applovin-adapter:13.5.1.0")
-    implementation("org.bidon:bidmachine-adapter:3.6.1.0")
-    implementation("org.bidon:bigoads-adapter:5.6.2.0")
-    implementation("org.bidon:chartboost-adapter:9.10.2.0")
-    implementation("org.bidon:dtexchange-adapter:8.4.1.0")
-    implementation("org.bidon:inmobi-adapter:11.1.0.0")
-    implementation("org.bidon:ironsource-adapter:9.1.0.0")
-    implementation("org.bidon:meta-adapter:6.20.0.0")
-    implementation("org.bidon:mintegral-adapter:17.0.31.0")
-    implementation("org.bidon:mobilefuse-adapter:1.9.3.0")
-    implementation("org.bidon:moloco-adapter:4.3.1.0")
-    implementation("org.bidon:startio-adapter:5.2.4.1")
-    implementation("org.bidon:taurusx-adapter:1.12.2.0")
-    implementation("org.bidon:unityads-adapter:4.16.4.1")
-    implementation("org.bidon:vkads-adapter:5.27.4.0")
-    implementation("org.bidon:vungle-adapter:7.6.1.0")
-    implementation("org.bidon:yandex-adapter:7.17.0.0")
-    implementation("org.bidon:zmaticoo-adapter:2.0.5.0.0")
+    implementation "com.appodeal.ads.sdk:core:4.2.0"
     // AppLovin MAX
-    implementation("com.applovin.mediation:amazon-tam-adapter:11.1.1.0")
-    implementation("com.applovin.mediation:bidmachine-adapter:3.6.1.0")
-    implementation("com.applovin.mediation:bigoads-adapter:5.6.2.0")
-    implementation("com.applovin.mediation:bytedance-adapter:7.7.0.2.0")
-    implementation("com.applovin.mediation:chartboost-adapter:9.10.2.0")
-    implementation("com.applovin.mediation:facebook-adapter:6.20.0.0")
-    implementation("com.applovin.mediation:fyber-adapter:8.4.1.0")
-    implementation("com.applovin.mediation:google-ad-manager-adapter:24.7.0.0")
-    implementation("com.applovin.mediation:google-adapter:24.7.0.0")
-    implementation("com.applovin.mediation:inmobi-adapter:11.1.0.0")
-    implementation("com.applovin.mediation:ironsource-adapter:9.1.0.0.0")
-    implementation("com.applovin.mediation:mintegral-adapter:17.0.31.0")
-    implementation("com.applovin.mediation:mobilefuse-adapter:1.9.3.0")
-    implementation("com.applovin.mediation:moloco-adapter:4.3.1.0")
-    implementation("com.applovin.mediation:mytarget-adapter:5.27.4.0")
-    implementation("com.applovin.mediation:ogury-presage-adapter:6.2.0.0")
-    implementation("com.applovin.mediation:pubmatic-adapter:4.10.0.0")
-    implementation("com.applovin.mediation:smaato-adapter:22.7.2.3")
-    implementation("com.applovin.mediation:unityads-adapter:4.16.4.0")
-    implementation("com.applovin.mediation:verve-adapter:3.7.1.0")
-    implementation("com.applovin.mediation:vungle-adapter:7.6.1.0")
-    implementation("com.applovin.mediation:yandex-adapter:7.17.0.0")
+    implementation "com.applovin.mediation:amazon-tam-adapter:11.3.0.0"
+    implementation "com.applovin.mediation:bidmachine-adapter:3.7.1.0"
+    implementation "com.applovin.mediation:bigoads-adapter:5.6.2.0"
+    implementation "com.applovin.mediation:bytedance-adapter:8.1.0.3.0"
+    implementation "com.applovin.mediation:chartboost-adapter:9.10.2.0"
+    implementation "com.applovin.mediation:facebook-adapter:6.21.0.0"
+    implementation "com.applovin.mediation:fyber-adapter:8.4.1.0"
+    implementation "com.applovin.mediation:google-ad-manager-adapter:24.7.0.0"
+    implementation "com.applovin.mediation:google-adapter:24.7.0.0"
+    implementation "com.applovin.mediation:inmobi-adapter:11.1.0.0"
+    implementation "com.applovin.mediation:ironsource-adapter:9.1.0.0.0"
+    implementation "com.applovin.mediation:mintegral-adapter:17.1.61.0"
+    implementation "com.applovin.mediation:mobilefuse-adapter:1.9.3.0"
+    implementation "com.applovin.mediation:moloco-adapter:4.3.1.0"
+    implementation "com.applovin.mediation:mytarget-adapter:5.47.1.0"
+    implementation "com.applovin.mediation:ogury-presage-adapter:6.2.0.0"
+    implementation "com.applovin.mediation:pubmatic-adapter:4.10.0.0"
+    implementation "com.applovin.mediation:smaato-adapter:22.7.2.3"
+    implementation "com.applovin.mediation:unityads-adapter:4.17.0.0"
+    implementation "com.applovin.mediation:verve-adapter:3.7.1.0"
+    implementation "com.applovin.mediation:vungle-adapter:7.6.1.0"
+    implementation "com.applovin.mediation:yandex-adapter:7.17.0.0"
     // Level Play
-    implementation("com.unity3d.ads-mediation:admob-adapter:5.2.0")
-    implementation("com.unity3d.ads-mediation:applovin-adapter:5.2.0")
-    implementation("com.unity3d.ads-mediation:bigo-adapter:5.3.0")
-    implementation("com.unity3d.ads-mediation:facebook-adapter:5.0.0")
-    implementation("com.unity3d.ads-mediation:fyber-adapter:5.1.0")
-    implementation("com.unity3d.ads-mediation:inmobi-adapter:5.3.0")
-    implementation("com.unity3d.ads-mediation:mintegral-adapter:5.6.0")
-    implementation("com.unity3d.ads-mediation:mobilefuse-adapter:5.1.0")
-    implementation("com.unity3d.ads-mediation:moloco-adapter:5.5.0")
-    implementation("com.unity3d.ads-mediation:mytarget-adapter:5.2.0")
-    implementation("com.unity3d.ads-mediation:ogury-adapter:5.2.0")
-    implementation("com.unity3d.ads-mediation:pangle-adapter:5.3.0")
-    implementation("com.unity3d.ads-mediation:smaato-adapter:5.0.0")
-    implementation("com.unity3d.ads-mediation:unityads-adapter:5.3.0")
-    implementation("com.unity3d.ads-mediation:verve-adapter:5.2.0")
-    implementation("com.unity3d.ads-mediation:vungle-adapter:5.4.0")
+    implementation "com.unity3d.ads-mediation:admob-adapter:5.2.0"
+    implementation "com.unity3d.ads-mediation:applovin-adapter:5.2.0"
+    implementation "com.unity3d.ads-mediation:bidmachine-adapter:5.7.0"
+    implementation "com.unity3d.ads-mediation:bigo-adapter:5.3.0"
+    implementation "com.unity3d.ads-mediation:facebook-adapter:5.2.0"
+    implementation "com.unity3d.ads-mediation:fyber-adapter:5.2.0"
+    implementation "com.unity3d.ads-mediation:inmobi-adapter:5.3.0"
+    implementation "com.unity3d.ads-mediation:mintegral-adapter:5.15.0"
+    implementation "com.unity3d.ads-mediation:mobilefuse-adapter:5.1.0"
+    implementation "com.unity3d.ads-mediation:moloco-adapter:5.5.0"
+    implementation "com.unity3d.ads-mediation:mytarget-adapter:5.5.0"
+    implementation "com.unity3d.ads-mediation:ogury-adapter:5.2.0"
+    implementation "com.unity3d.ads-mediation:pangle-adapter:5.18.0"
+    implementation "com.unity3d.ads-mediation:smaato-adapter:5.0.0"
+    implementation "com.unity3d.ads-mediation:unityads-adapter:5.6.0"
+    implementation "com.unity3d.ads-mediation:verve-adapter:5.2.0"
+    implementation "com.unity3d.ads-mediation:vungle-adapter:5.4.0"
     // BidMachine
-    implementation("io.bidmachine:ads.networks.amazon:11.1.1.0")
-    implementation("io.bidmachine:ads.networks.meta_audience:6.20.0.0")
-    implementation("io.bidmachine:ads.networks.mintegral:17.0.31.0")
-    implementation("io.bidmachine:ads.networks.my_target:5.27.4.0")
-    implementation("io.bidmachine:ads.networks.pangle:7.7.0.2.0")
-    implementation("io.bidmachine:ads.networks.vungle:7.6.1.0")
+    implementation "io.bidmachine:ads.networks.amazon:11.3.0.2"
+    implementation "io.bidmachine:ads.networks.meta_audience:6.21.0.1"
+    implementation "io.bidmachine:ads.networks.mintegral:17.1.61.1"
+    implementation "io.bidmachine:ads.networks.my_target:5.47.1.2"
+    implementation "io.bidmachine:ads.networks.vungle:7.6.1.2"
+    // Bidon
+    implementation "org.bidon:amazon-adapter:11.3.0.0"
+    implementation "org.bidon:applovin-adapter:13.5.1.0"
+    implementation "org.bidon:bidmachine-adapter:3.7.1.0"
+    implementation "org.bidon:bigoads-adapter:5.6.2.0"
+    implementation "org.bidon:chartboost-adapter:9.10.2.0"
+    implementation "org.bidon:dtexchange-adapter:8.4.1.0"
+    implementation "org.bidon:inmobi-adapter:11.1.0.0"
+    implementation "org.bidon:ironsource-adapter:9.1.0.0"
+    implementation "org.bidon:meta-adapter:6.21.0.0"
+    implementation "org.bidon:mintegral-adapter:17.1.61.0"
+    implementation "org.bidon:mobilefuse-adapter:1.9.3.0"
+    implementation "org.bidon:moloco-adapter:4.3.1.0"
+    implementation "org.bidon:startio-adapter:5.2.4.1"
+    implementation "org.bidon:taurusx-adapter:1.12.2.0"
+    implementation "org.bidon:unityads-adapter:4.17.0.0"
+    implementation "org.bidon:vkads-adapter:5.47.1.0"
+    implementation "org.bidon:vungle-adapter:7.6.1.0"
+    implementation "org.bidon:yandex-adapter:7.17.0.0"
+    implementation "org.bidon:zmaticoo-adapter:2.0.6.0.0"
     // Appodeal
-    implementation("com.appodeal.ads.sdk.adapters:adjust:5.4.6.1")
-    implementation("com.appodeal.ads.sdk.adapters:admob:24.7.0.0")
-    implementation("com.appodeal.ads.sdk.adapters:amazon:11.1.1.1")
-    implementation("com.appodeal.ads.sdk.adapters:applovin:13.5.1.0")
-    implementation("com.appodeal.ads.sdk.adapters:applovin_max:13.5.1.1")
-    implementation("com.appodeal.ads.sdk.adapters:appsflyer:6.17.3.1")
-    implementation("com.appodeal.ads.sdk.adapters:bidmachine:3.6.1.0")
-    implementation("com.appodeal.ads.sdk.adapters:bidon:0.13.0.0")
-    implementation("com.appodeal.ads.sdk.adapters:bigo_ads:5.6.2.0")
-    implementation("com.appodeal.ads.sdk.adapters:chartboost:9.10.2.0")
-    implementation("com.appodeal.ads.sdk.adapters:dt_exchange:8.4.1.0")
-    implementation("com.appodeal.ads.sdk.adapters:facebook_analytics:18.0.3.0")
-    implementation("com.appodeal.ads.sdk.adapters:firebase:23.0.0.1")
-    implementation("com.appodeal.ads.sdk.adapters:iab:1.8.1.0")
-    implementation("com.appodeal.ads.sdk.adapters:inmobi:11.1.0.0")
-    implementation("com.appodeal.ads.sdk.adapters:ironsource:9.1.0.0")
-    implementation("com.appodeal.ads.sdk.adapters:level_play:9.1.0.0")
-    implementation("com.appodeal.ads.sdk.adapters:meta:6.20.0.0")
-    implementation("com.appodeal.ads.sdk.adapters:mintegral:17.0.31.0")
-    implementation("com.appodeal.ads.sdk.adapters:mobilefuse:1.9.3.0")
-    implementation("com.appodeal.ads.sdk.adapters:moloco:4.3.1.0")
-    implementation("com.appodeal.ads.sdk.adapters:my_target:5.27.4.0")
-    implementation("com.appodeal.ads.sdk.adapters:ogury:6.2.0.0")
-    implementation("com.appodeal.ads.sdk.adapters:pangle:7.7.0.2.0")
-    implementation("com.appodeal.ads.sdk.adapters:pubmatic:4.10.0.0")
-    implementation("com.appodeal.ads.sdk.adapters:sentry_analytics:8.26.0.0")
-    implementation("com.appodeal.ads.sdk.adapters:smaato:22.7.2.0")
-    implementation("com.appodeal.ads.sdk.adapters:startio:5.2.4.0")
-    implementation("com.appodeal.ads.sdk.adapters:taurusx:1.12.2.0")
-    implementation("com.appodeal.ads.sdk.adapters:unity_ads:4.16.4.0")
-    implementation("com.appodeal.ads.sdk.adapters:verve:3.7.1.0")
-    implementation("com.appodeal.ads.sdk.adapters:vungle:7.6.1.0")
-    implementation("com.appodeal.ads.sdk.adapters:yandex:7.17.0.0")
+    implementation "com.appodeal.ads.sdk.adapters:adjust:5.4.6.1"
+    implementation "com.appodeal.ads.sdk.adapters:admob:24.7.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:amazon:11.3.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:applovin:13.5.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:applovin_max:13.5.1.1"
+    implementation "com.appodeal.ads.sdk.adapters:appsflyer:6.18.0.1"
+    implementation "com.appodeal.ads.sdk.adapters:bidmachine:3.7.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:bidon:0.14.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:bigo_ads:5.6.2.0"
+    implementation "com.appodeal.ads.sdk.adapters:chartboost:9.10.2.0"
+    implementation "com.appodeal.ads.sdk.adapters:dt_exchange:8.4.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:facebook_analytics:18.0.3.0"
+    implementation "com.appodeal.ads.sdk.adapters:firebase:23.0.0.1"
+    implementation "com.appodeal.ads.sdk.adapters:iab:1.8.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:inmobi:11.1.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:ironsource:9.1.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:level_play:9.1.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:meta:6.21.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:mintegral:17.1.61.0"
+    implementation "com.appodeal.ads.sdk.adapters:mobilefuse:1.9.3.0"
+    implementation "com.appodeal.ads.sdk.adapters:moloco:4.3.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:my_target:5.47.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:ogury:6.2.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:pubmatic:4.10.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:sentry_analytics:8.26.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:smaato:22.7.2.0"
+    implementation "com.appodeal.ads.sdk.adapters:startio:5.2.4.0"
+    implementation "com.appodeal.ads.sdk.adapters:taurusx:1.12.2.0"
+    implementation "com.appodeal.ads.sdk.adapters:unity_ads:4.17.0.0"
+    implementation "com.appodeal.ads.sdk.adapters:verve:3.7.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:vungle:7.6.1.0"
+    implementation "com.appodeal.ads.sdk.adapters:yandex:7.17.0.0"
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -3,3 +3,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -8,7 +8,7 @@ def flutter_root
   unless File.exist?(generated_xcode_build_settings_path)
     raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end
-  
+
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
     return matches[1].strip if matches
@@ -27,10 +27,10 @@ source 'https://github.com/appodeal/CocoaPods.git'
 source 'https://github.com/bidon-io/CocoaPods-Specs.git'
 
 def appodeal
-   pod 'Appodeal', '4.1.0'
+   pod 'Appodeal', '4.2.0'
    # AppLovin MAX
    pod 'AppLovinMediationAmazonAdMarketplaceAdapter', '5.3.2.0'
-   pod 'AppLovinMediationBidMachineAdapter', '3.6.1.0.0'
+   pod 'AppLovinMediationBidMachineAdapter', '3.7.1.0.0'
    pod 'AppLovinMediationBigoAdsAdapter', '5.0.0.0'
    pod 'AppLovinMediationByteDanceAdapter', '7.7.0.7.0'
    pod 'AppLovinMediationChartboostAdapter', '9.10.1.0'
@@ -46,15 +46,15 @@ def appodeal
    pod 'AppLovinMediationMyTargetAdapter', '5.36.2.0'
    pod 'AppLovinMediationOguryPresageAdapter', '5.1.1.0'
    pod 'AppLovinMediationPubMaticAdapter', '4.10.0.0'
-   pod 'AppLovinMediationSmaatoAdapter', '22.9.3.1'
+   pod 'AppLovinMediationSmaatoAdapter', '23.1.0.0'
    pod 'AppLovinMediationUnityAdsAdapter', '4.16.3.0'
-   pod 'AppLovinMediationVerveAdapter', '3.7.0.0'
+   pod 'AppLovinMediationVerveAdapter', '3.8.1.0'
    pod 'AppLovinMediationVungleAdapter', '7.6.2.0'
    pod 'AppLovinMediationYandexAdapter', '7.17.0.0'
    # Level Play
    pod 'IronSourceAdMobAdapter', '5.3.0.0'
    pod 'IronSourceAppLovinAdapter', '5.3.0.0'
-   pod 'IronSourceBidMachineAdapter', '5.4.0.0'
+   pod 'IronSourceBidMachineAdapter', '5.7.0.0'
    pod 'IronSourceBigoAdapter', '5.1.0.0'
    pod 'IronSourceFacebookAdapter', '5.0.0.0'
    pod 'IronSourceFyberAdapter', '5.2.0.0'
@@ -65,14 +65,38 @@ def appodeal
    pod 'IronSourceMyTargetAdapter', '5.3.0.0'
    pod 'IronSourceOguryAdapter', '5.0.0.0'
    pod 'IronSourcePangleAdapter', '5.5.0.0'
-   pod 'IronSourceSmaatoAdapter', '5.0.0.0'
+   pod 'IronSourceSmaatoAdapter', '5.2.0.0'
    pod 'IronSourceUnityAdsAdapter', '5.2.0.0'
-   pod 'IronSourceVerveAdapter', '5.1.0.0'
+   pod 'IronSourceVerveAdapter', '5.5.0.0'
    pod 'IronSourceVungleAdapter', '5.3.0.0'
+   # Appodeal
+   pod 'AppodealAdjustAdapter', '5.4.6.1'
+   pod 'AppodealAmazonAdapter', '5.3.2.0'
+   pod 'AppodealAppLovinAdapter', '13.5.1.0'
+   pod 'AppodealAppLovinMAXAdapter', '13.5.1.1'
+   pod 'AppodealAppsFlyerAdapter', '6.17.7.1'
+   pod 'AppodealBidMachineAdapter', '3.7.1.0'
+   pod 'AppodealBidonAdapter', '0.15.0.0'
+   pod 'AppodealBigoAdsAdapter', '5.0.0.0'
+   pod 'AppodealDTExchangeAdapter', '8.4.1.0'
+   pod 'AppodealFacebookAdapter', '18.0.1.0'
+   pod 'AppodealFirebaseAdapter', '12.4.0.1'
+   pod 'AppodealGoogleAdMobAdapter', '12.13.0.0'
+   pod 'AppodealIABAdapter', '3.5.0.0'
+   pod 'AppodealInMobiAdapter', '11.1.0.0'
+   pod 'AppodealIronSourceAdapter', '9.1.0.0.0'
+   pod 'AppodealLevelPlayAdapter', '9.1.0.0.0'
+   pod 'AppodealMetaAudienceNetworkAdapter', '6.20.1.0'
+   pod 'AppodealMintegralAdapter', '7.7.9.0'
+   pod 'AppodealMyTargetAdapter', '5.36.2.0'
+   pod 'AppodealSentryAdapter', '8.57.2.1'
+   pod 'AppodealUnityAdapter', '4.16.3.0'
+   pod 'AppodealVungleAdapter', '7.6.2.0'
+   pod 'AppodealYandexAdapter', '7.17.0.1'
    # Bidon
    pod 'BidonAdapterAmazon', '5.3.2.0'
    pod 'BidonAdapterAppLovin', '13.5.1.0'
-   pod 'BidonAdapterBidMachine', '3.6.1.0'
+   pod 'BidonAdapterBidMachine', '3.7.1.1'
    pod 'BidonAdapterBigoAds', '5.0.0.0'
    pod 'BidonAdapterChartboost', '9.10.1.0'
    pod 'BidonAdapterDTExchange', '8.4.1.0'
@@ -83,43 +107,19 @@ def appodeal
    pod 'BidonAdapterMobileFuse', '1.9.3.0'
    pod 'BidonAdapterMoloco', '4.1.0.0'
    pod 'BidonAdapterMyTarget', '5.36.2.0'
-   pod 'BidonAdapterStartIo', '4.12.0.0'
-   pod 'BidonAdapterTaurusX', '1.9.2.0'
+   pod 'BidonAdapterStartIo', '4.13.0.0'
+   pod 'BidonAdapterTaurusX', '1.15.0.0'
    pod 'BidonAdapterUnityAds', '4.16.3.0'
    pod 'BidonAdapterVungle', '7.6.2.0'
    pod 'BidonAdapterYandex', '7.17.0.0'
-   pod 'BidonAdapterZmaticoo', '1.5.6.0'
-   # Appodeal
-   pod 'AppodealAdjustAdapter', '5.4.6.1'
-   pod 'AppodealAmazonAdapter', '5.3.2.0'
-   pod 'AppodealAppLovinAdapter', '13.5.1.0'
-   pod 'AppodealAppLovinMAXAdapter', '13.5.1.1'
-   pod 'AppodealAppsFlyerAdapter', '6.17.7.1'
-   pod 'AppodealBidMachineAdapter', '3.6.1.0'
-   pod 'AppodealBidonAdapter', '0.14.0.1'
-   pod 'AppodealBigoAdsAdapter', '5.0.0.0'
-   pod 'AppodealDTExchangeAdapter', '8.4.1.0'
-   pod 'AppodealFacebookAdapter', '18.0.1.0'
-   pod 'AppodealFirebaseAdapter', '12.4.0.1'
-   pod 'AppodealGoogleAdMobAdapter', '12.13.0.0'
-   pod 'AppodealIABAdapter', '3.4.7.0'
-   pod 'AppodealInMobiAdapter', '11.1.0.0'
-   pod 'AppodealIronSourceAdapter', '9.1.0.0.0'
-   pod 'AppodealLevelPlayAdapter', '9.1.0.0.0'
-   pod 'AppodealMetaAudienceNetworkAdapter', '6.20.1.0'
-   pod 'AppodealMintegralAdapter', '7.7.9.0'
-   pod 'AppodealMyTargetAdapter', '5.36.2.0'
-   pod 'AppodealSentryAdapter', '8.57.2.0'
-   pod 'AppodealUnityAdapter', '4.16.3.0'
-   pod 'AppodealVungleAdapter', '7.6.2.0'
-   pod 'AppodealYandexAdapter', '7.17.0.1'
+   pod 'BidonAdapterZmaticoo', '2.2.0.0'
 end
 
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
   appodeal
-  
+
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 

--- a/example/lib/consent_view.dart
+++ b/example/lib/consent_view.dart
@@ -55,6 +55,24 @@ class _ConsentPageState extends State<ConsentPage> {
     Appodeal.ConsentForm.revoke();
   }
 
+  getPrivacyOptionsRequirementStatus() async {
+    final status =
+        await Appodeal.ConsentForm.getPrivacyOptionsRequirementStatus();
+    print("getPrivacyOptionsRequirementStatus: status - $status");
+  }
+
+  showPrivacyOptionsForm() {
+    Appodeal.ConsentForm.showPrivacyOptionsForm(
+      onConsentFormDismissed: (error) {
+        if (error != null) {
+          print("showPrivacyOptionsForm dismissed: error - ${error.description}");
+        } else {
+          print("showPrivacyOptionsForm dismissed: No error");
+        }
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -65,7 +83,7 @@ class _ConsentPageState extends State<ConsentPage> {
       ),
       body: Padding(
         padding: const EdgeInsets.all(10.0),
-        child: Column(children: [
+        child: Column(spacing: 12, children: [
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
@@ -123,6 +141,42 @@ class _ConsentPageState extends State<ConsentPage> {
                   revoke();
                 },
                 child: const Text('REVOKE CONSENT'),
+              ),
+            ],
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                    textStyle: const TextStyle(fontSize: 20),
+                    fixedSize: Size.fromWidth(300)),
+                onPressed: () {
+                  getPrivacyOptionsRequirementStatus();
+                },
+                child: const Text(
+                  'PRIVACY OPTIONS REQUIREMENT STATUS',
+                  maxLines: 2,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                    textStyle: const TextStyle(fontSize: 20),
+                    fixedSize: Size.fromWidth(300)),
+                onPressed: () {
+                  showPrivacyOptionsForm();
+                },
+                child: const Text(
+                  'SHOW PRIVACY OPTIONS FORM',
+                  maxLines: 2,
+                  textAlign: TextAlign.center,
+                ),
               ),
             ],
           ),

--- a/ios/Classes/AppodealConsentManager.swift
+++ b/ios/Classes/AppodealConsentManager.swift
@@ -19,6 +19,8 @@ internal final class AppodealConsentManager {
         case "show": show(call, result)
         case "loadAndShowIfRequired": loadAndShowIfRequired(call, result)
         case "revoke": revoke(call, result)
+        case "getPrivacyOptionsRequirementStatus": getPrivacyOptionsRequirementStatus(call, result)
+        case "showPrivacyOptionsForm": showPrivacyOptionsForm(call, result)
         default: result(FlutterMethodNotImplemented)
         }
     }
@@ -120,6 +122,36 @@ internal final class AppodealConsentManager {
     
     private func revoke(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         ConsentManager.shared.revoke()
+        result(nil)
+    }
+
+    private func getPrivacyOptionsRequirementStatus(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        // Normalized to match the Dart PrivacyOptionsRequirementStatus enum and the Android side:
+        // 0 = unknown, 1 = required, 2 = notRequired.
+        let normalized: Int
+        switch ConsentManager.shared.privacyOptionsRequirementStatus {
+        case .required: normalized = 1
+        case .notRequired: normalized = 2
+        default: normalized = 0
+        }
+        result(normalized)
+    }
+
+    private func showPrivacyOptionsForm(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        guard let rootViewController = UIApplication.shared.keyWindow?.rootViewController else {
+            let args: [String: String] = ["error": "Root view controller is nil"]
+            self.adChannel.invokeMethod("onConsentFormDismissed", arguments: args)
+            return
+        }
+
+        ConsentManager.shared.showPrivacyOptionsForm(rootViewController: rootViewController) { error in
+            if let error = error {
+                let args: [String: String] = ["error": error.localizedDescription]
+                self.adChannel.invokeMethod("onConsentFormDismissed", arguments: args)
+            } else {
+                self.adChannel.invokeMethod("onConsentFormDismissed", arguments: nil)
+            }
+        }
         result(nil)
     }
 }

--- a/ios/stack_appodeal_flutter.podspec
+++ b/ios/stack_appodeal_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'stack_appodeal_flutter'
-  s.version          = '4.1.0'
+  s.version          = '4.2.0'
   s.summary          = 'Appodeal flutter plugin'
   s.description      = <<-DESC
   Flutter plugin for Appodeal SDK. It supports interstitial, rewarded video and banner ads.
@@ -20,8 +20,8 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'Flutter'
-  s.dependency "Appodeal", "4.1.0"
-  s.dependency "AppodealIABAdapter", "3.4.7.0"
+  s.dependency "Appodeal", "4.2.0"
+  s.dependency "AppodealIABAdapter", "3.5.0.0"
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/lib/src/appodeal.dart
+++ b/lib/src/appodeal.dart
@@ -347,7 +347,7 @@ class Appodeal {
 
   /// Gets SDK version.
   static String getSDKVersion() {
-    return "4.1.0";
+    return "4.2.0";
   }
 
   /// Gets SDK platform version.

--- a/lib/src/appodeal_consent_manager.dart
+++ b/lib/src/appodeal_consent_manager.dart
@@ -88,6 +88,48 @@ class AppodealConsentForm {
     _invokeMethod('revoke');
   }
 
+  /// Returns whether a Privacy Entry Point button must be surfaced in the app UI.
+  ///
+  /// US state privacy laws (CCPA, CPA, VCDPA, and others) follow an opt-out model:
+  /// data processing is allowed by default, but users must be given a permanent way
+  /// to opt out — typically a "Do Not Sell or Share My Personal Information" button.
+  ///
+  /// Returns [PrivacyOptionsRequirementStatus.required] for users in regulated US
+  /// states and in the EEA (for GDPR re-consent), [PrivacyOptionsRequirementStatus.notRequired]
+  /// elsewhere, and [PrivacyOptionsRequirementStatus.unknown] before
+  /// [load] / [loadAndShowIfRequired] (i.e. requestConsentInfoUpdate) has completed.
+  Future<PrivacyOptionsRequirementStatus>
+      getPrivacyOptionsRequirementStatus() async {
+    final value = await _consentManagerChannel
+        .invokeMethod<int>('getPrivacyOptionsRequirementStatus');
+    return _PrivacyOptionsRequirementStatusExtension._fromInt(value ?? 0);
+  }
+
+  /// Shows the US opt-out form (or the GDPR re-consent form in the EEA).
+  ///
+  /// Call this from the action handler of your Privacy Entry Point button. This is
+  /// the only way to display the US opt-out form, and it must be triggered by an
+  /// explicit user interaction — not at app launch. Available only after
+  /// [load] / [loadAndShowIfRequired] (i.e. requestConsentInfoUpdate) has completed.
+  ///
+  /// Parameters:
+  /// - [onConsentFormDismissed]: Callback for when the form is dismissed. A non-null
+  ///   [ConsentError] means the form could not be presented.
+  void showPrivacyOptionsForm({
+    void Function(ConsentError? error)? onConsentFormDismissed,
+  }) {
+    _setHandler({
+      'onConsentFormDismissed': (arguments) {
+        final error = arguments?['error'] != null
+            ? ConsentError._(arguments['error'])
+            : null;
+        onConsentFormDismissed?.call(error);
+      },
+    });
+
+    _invokeMethod('showPrivacyOptionsForm');
+  }
+
   /// Helper method to set a method call handler with specific callbacks.
   void _setHandler(Map<String, Function(dynamic arguments)> handlers) {
     _consentManagerChannel.setMethodCallHandler((call) async {
@@ -147,6 +189,37 @@ extension _ConsentStatusExtension on ConsentStatus {
         return ConsentStatus.obtained;
       default:
         return ConsentStatus.unknown;
+    }
+  }
+}
+
+/// Appodeal SDK Privacy Options Requirement Status enum.
+///
+/// Indicates whether a Privacy Entry Point button (US opt-out / GDPR re-consent)
+/// must be surfaced in the app UI.
+enum PrivacyOptionsRequirementStatus {
+  /// Status is not yet known (requestConsentInfoUpdate has not completed).
+  unknown,
+
+  /// A Privacy Entry Point button is required (regulated US state or EEA re-consent).
+  required,
+
+  /// A Privacy Entry Point button is not required.
+  notRequired
+}
+
+/// Extension on [PrivacyOptionsRequirementStatus] for converting from integer values.
+extension _PrivacyOptionsRequirementStatusExtension
+    on PrivacyOptionsRequirementStatus {
+  /// Converts a normalized integer (sent by the native side) to an enum value.
+  static PrivacyOptionsRequirementStatus _fromInt(int value) {
+    switch (value) {
+      case 1:
+        return PrivacyOptionsRequirementStatus.required;
+      case 2:
+        return PrivacyOptionsRequirementStatus.notRequired;
+      default:
+        return PrivacyOptionsRequirementStatus.unknown;
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stack_appodeal_flutter
 description: Official Flutter plugin to support Appodeal SDK for Android and iOS platforms. Support Consent Dialog for GDPR/CCPA zone.
-version: 4.1.0
+version: 4.2.0
 homepage: https://github.com/appodeal
 repository: https://github.com/appodeal/Appodeal-Flutter-Plugin
 


### PR DESCRIPTION
## Summary

Updates the plugin to Appodeal SDK **4.2.0** (Android + iOS) and implements the new 4.2.0 Privacy Entry Point API.

## Changes

### SDK / dependencies
- Appodeal Android SDK → 4.2.0 (`core:4.2.0`)
- Appodeal iOS SDK → 4.2.0 (`Appodeal 4.2.0`, `AppodealIABAdapter 3.5.0.0`)
- README dependency lists regenerated from the Wizard API; example `build.gradle` and `Podfile` aligned with them
- `getSDKVersion()` → `4.2.0`

### Migration
- **Android minSdk 23 → 24** (SDK 4.2.0 requirement)
- example `compileSdk`/`targetSdk` → 36
- example Gradle wrapper → 8.14

### New API — Privacy Entry Point (US State Regulations / GDPR re-consent)
- `ConsentForm.getPrivacyOptionsRequirementStatus()` → new `PrivacyOptionsRequirementStatus` enum
- `ConsentForm.showPrivacyOptionsForm({onConsentFormDismissed})`
- Wired across Dart / Android (Kotlin) / iOS (Swift) with a **normalized** status mapping (`0=unknown, 1=required, 2=notRequired`) to avoid native-ordinal divergence
- Example: new buttons + spacing between consent buttons

## Note: iOS AdMob / Bidon (issue #114)
4.2.0 resolves #114: `AppodealGoogleAdMobAdapter 12.13.0.0` now requires `Bidon = 0.15.0`, and the matching `AppodealBidonAdapter 0.15.0.0` is published — both align on `Bidon 0.15.0`. Upgrading requires deleting a stale `Podfile.lock` (it pins the old `Bidon 0.14.0`).

## Validation
- **Android:** APK builds; runs on emulator (API 36); Privacy flow exercised end-to-end (status → form shown as dialog overlay → dismiss callback `No error`)
- **iOS:** `pod install` clean (170 pods); Swift compiles; `Runner.app` built; runs on iOS 18.5 sim; `getPrivacyOptionsRequirementStatus` → `.required`; privacy form renders
- `flutter pub publish --dry-run` → 0 warnings

### Not verified
- iOS `onConsentFormDismissed` runtime callback (form rendered, but WebView buttons weren't tappable on the simulator; confirmed on Android)
- Real ad serving smoke test (only consent flow tested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)